### PR TITLE
Don't set massless atoms to unit mass when calculating CoM

### DIFF
--- a/pmx/atomselection.py
+++ b/pmx/atomselection.py
@@ -166,17 +166,16 @@ class Atomselection:
             
     def com(self,vector_only=False):
         """move atoms to center of mass or return vector only"""
-        for atom in self.atoms:
-            if atom.m == 0:
-                print(" Warning: Atom has zero mass: setting mass to 1.", file=sys.stderr)
-                atom.m = 1.
-        x = sum([a.x[0]*a.m for a in self.atoms])
-        y = sum([a.x[1]*a.m for a in self.atoms])
-        z = sum([a.x[2]*a.m for a in self.atoms])
         M = sum([a.m for a in self.atoms])
-        x/=M
-        y/=M
-        z/=M
+        if M == 0:
+            # Zero total mass, so treat all atoms as having equal mass
+            x = sum([a.x[0] for a in self.atoms])
+            y = sum([a.x[1] for a in self.atoms])
+            z = sum([a.x[2] for a in self.atoms])
+        else:
+            x = sum([a.x[0]*a.m for a in self.atoms]) / M
+            y = sum([a.x[1]*a.m for a in self.atoms]) / M
+            z = sum([a.x[2]*a.m for a in self.atoms]) / M
         if vector_only:
             return [x,y,z]
         else:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ pmx = Extension('pmx/_pmx',
 
 
 setup (name = 'pmx',
-       version = '1.0.1',
+       version = '1.0.2',
        description = 'Python Toolbox structure file editing and writing simulation setup/analysis tools',
        author = 'Martin Stroet, Daniel Seeliger',
        author_email = 'm.stroet@uq.edu.au',


### PR DESCRIPTION
The CoM routine was setting massless atoms to have unit mass, which is problematic for (e.g.) 4-point water models (see ATB-UQ/PyThinFilm#12).

This patch takes an alternative approach:
* Molecules with a non-zero total mass calculate CoM from massive atoms only.
* Molecules with zero *total* mass calculate CoM as if all atoms had unit mass, but actual atom masses are not modified.

Includes version bump since this is a change in behaviour.